### PR TITLE
Force StalkerBot to use ascii keys for its storage

### DIFF
--- a/stalkerBot.py
+++ b/stalkerBot.py
@@ -17,7 +17,7 @@ class StalkerBot(BotPlugin):
         if not message:
             return
 
-        username = get_jid_from_message(mess)
+        username = str(get_jid_from_message(mess)).encode('ascii', 'replace')
         self.shelf[username] = datetime.now()
         self.shelf.sync()
 


### PR DESCRIPTION
StalkerBot was relying on the implicit call to **str** when the key is
computed. Python on my computer was not accepting this as the dictionary
key and wanted it to be a ascii string. This makes it so.
